### PR TITLE
Ignore temporary files starting with '~'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,7 @@ mono_crash.*.json
 
 # Temporary file ignores
 *.tmp
-~*.*
+~*
 
 # Custom ignores
 build/
-Godot/addons/fmod/libs/windows/~libGodotFmod.windows.editor.x86_64.dll

--- a/Godot/addons/fmod/.gitignore
+++ b/Godot/addons/fmod/.gitignore
@@ -5,3 +5,6 @@
 *.so
 *.xcframework
 !libs/**
+
+# Temporary files
+~*


### PR DESCRIPTION
A stubborn temporary file in the FMOD addon libraries wasn't getting ignored because of the separate .gitignore rules.