### PR TITLE
change main scene to main.tscn

### DIFF
--- a/Godot/project.godot
+++ b/Godot/project.godot
@@ -29,7 +29,7 @@ General/banks_path="res://audio/fmod banks/Desktop"
 [application]
 
 config/name="Death Party"
-run/main_scene="uid://bdw28hmsvnwb0"
+run/main_scene="uid://beuct1pjdlayy"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
change the project's main scene from the node_3d scene to main

whenever i saved in main or this branch i got some random changes with import files (and also some random whitespace changes in main.tscn)
![image](https://github.com/user-attachments/assets/ce43448b-0952-4e11-98e6-f381fedb6d6d)

i discarded those so hopefully theres no issues here - this pr just changes the one line in project.godot which declares the main scene