### PR TITLE
fix door sfx positions

### DIFF
--- a/Godot/World/door.tscn
+++ b/Godot/World/door.tscn
@@ -53,7 +53,8 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.1, -1.5)
 [node name="EntranceLocation" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.1, 2.5)
 
-[node name="Sfx" type="Node" parent="."]
+[node name="Sfx" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.5, 1, 0)
 
 [node name="OpenSound" type="FmodEventEmitter3D" parent="Sfx"]
 event_name = "event:/000_SFX/000_Demo_Test/005_SFX_DoorOpen"


### PR DESCRIPTION
for the audio nodes in the main scene, grouping them under a Node still played them from the correct positions, but for these nodes (children of 2 instances of the same door scene) they only played correctly when grouped under a Node3D