### PR TITLE
refactor pause input logic

### DIFF
--- a/Godot/Utilities/pause menu/pause_menu.gd
+++ b/Godot/Utilities/pause menu/pause_menu.gd
@@ -23,10 +23,7 @@ func _ready() -> void:
 
 func _physics_process(_delta : float) -> void:
 	if Input.is_action_just_pressed("pause"):
-		if main_pause_menu.visible:
-			toggle_pause()
-
-		elif settings_menu.visible:
+		if settings_menu.visible:
 			settings_menu.hide()
 			main_pause_menu.show()
 			settings_button.grab_focus()
@@ -35,6 +32,9 @@ func _physics_process(_delta : float) -> void:
 			quit_menu.hide()
 			main_pause_menu.show()
 			quit_button.grab_focus()
+
+		else:
+			toggle_pause()
 
 
 func toggle_pause() -> void:


### PR DESCRIPTION
was calling toggle_pause() from a weird unintuitive if statement, now calls it in `else:` after checking for different sub menus to back out of