### PR TITLE
move journal page flip sound calls directly under animation calls to prevent sfx playing on A or D inputs on first or last page

### DIFF
--- a/Godot/Assets/GUIPrefabs/JournalPrefabs/journal.tscn
+++ b/Godot/Assets/GUIPrefabs/JournalPrefabs/journal.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=3 uid="uid://b1q5i30ewr8bm"]
+[gd_scene load_steps=15 format=3 uid="uid://b1q5i30ewr8bm"]
 
 [ext_resource type="Script" uid="uid://b3qslxwn0wgdo" path="res://Assets/GUIDesignScripts/default_gui_button.gd" id="1_bvx4m"]
 [ext_resource type="Script" uid="uid://s411vv6436kp" path="res://character_info_button.gd" id="2_7dpwy"]
@@ -10,7 +10,6 @@
 [ext_resource type="Script" uid="uid://bqrg06p5aek3u" path="res://character_profile.gd" id="8_gg6ut"]
 [ext_resource type="PackedScene" uid="uid://bjm0d63pqk4j2" path="res://Assets/GUIPrefabs/JournalPrefabs/CharProfilePrefabs/char_note.tscn" id="9_5alca"]
 [ext_resource type="Texture2D" uid="uid://s742yxoo5vvv" path="res://Assets/CharacterAssets/CharacterTextures/kai_pikachu_waistup.png" id="10_l422v"]
-[ext_resource type="Texture2D" uid="uid://d2gcrhcr20py4" path="res://Assets/PNGAssets/scissors.png" id="11_lurp6"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_qsp4k"]
 
@@ -381,7 +380,6 @@ anchor_right = 0.97
 anchor_bottom = 0.97
 grow_horizontal = 2
 grow_vertical = 2
-texture = ExtResource("11_lurp6")
 expand_mode = 3
 stretch_mode = 5
 

--- a/Godot/Assets/models/bookflip_script.gd
+++ b/Godot/Assets/models/bookflip_script.gd
@@ -97,6 +97,7 @@ func bookflip(backward : bool = false, flip_to_page : int = -1):
 		set_page(1, old_page_index)
 		set_page(2, page_tracker)
 		animation_player.play("pageFlip")
+		page_flip_sound.play()
 		timer.start(.5)
 	elif backward && (page_tracker>0 || flip_to_page != -1):
 		flipping = true;
@@ -107,6 +108,7 @@ func bookflip(backward : bool = false, flip_to_page : int = -1):
 		set_page(1, page_tracker)
 		set_page(2, old_page_index)
 		animation_player.play_backwards("pageFlip")
+		page_flip_sound.play()
 		timer.start(.2)
 
 	#bring a bookmark up front
@@ -114,7 +116,6 @@ func bookflip(backward : bool = false, flip_to_page : int = -1):
 		if page_tracker == tab.flip_to_page:
 			cur_tab = tab
 
-	page_flip_sound.play()
 
 func _on_anim_finished(anim_name: StringName) -> void:
 	if anim_name == "pageFlip":


### PR DESCRIPTION
also removes a scissor texture asset from the journal scene (automatic change) - i think i had an error to say this was missing when i opened the project, so im guessing it was deleted and isnt needed but thought i should mention it @akatakprime