### PR TITLE
Disable verify-execution job

### DIFF
--- a/.github/workflows/publish_feature.yml
+++ b/.github/workflows/publish_feature.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build:
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
       - name: Checkout current branch

--- a/.github/workflows/verify_feature.yml
+++ b/.github/workflows/verify_feature.yml
@@ -40,7 +40,7 @@ jobs:
   build:
     if: ${{ !github.event.pull_request.draft }}
     needs: check-godot-version
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 8
     steps:
       - name: Checkout current branch
@@ -70,7 +70,7 @@ jobs:
     #if: ${{ !github.event.pull_request.draft }}
     if: false
     needs: build
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout current branch


### PR DESCRIPTION
Fix #92 by simply not running that job lol. I'm creating this as a draft because I also want to look into getting workflows running consistently again, although I think that's just an issue with the organization's billing settings. We have been working well within the free tier, but from some quick research it seems like GitHub still likes to have certain settings configured before it gives access to the full free tier.