### PR TITLE
add export var to Room3Ds for environment

### DIFF
--- a/Godot/Utilities/scripts/define_camera_bounds.gd
+++ b/Godot/Utilities/scripts/define_camera_bounds.gd
@@ -167,6 +167,8 @@ func keep_camera_off_player(body: Node3D) -> void:
 	GlobalCameraScript.camera_on_player.emit(false)
 
 
+# set the parameter that tells fmod which room the player is currently in
+# (based on the name the Room3D node)
 func set_fmod_room_parameter(body: Node3D, room_name: String) -> void:
 	#print("SETTING FMOD ROOM TO: ", room_name)
 	if body.is_in_group("player"):
@@ -174,14 +176,22 @@ func set_fmod_room_parameter(body: Node3D, room_name: String) -> void:
 	#print("FMOD ROOM IS NOW: ", FmodServer.get_global_parameter_by_name("Room"))
 
 
+# override the WorldEnvironment with this room's environment
+# (if one has been set for this room)
 func set_environment(body: Node3D) -> void:
 	if body.is_in_group("player"):
 		var camera: Camera3D = get_tree().current_scene.get_node("MainCamera")
 		if room_environment:
+			# wait for clear_environment() from the previous room to run first
 			await get_tree().process_frame
 			camera.environment = room_environment
 
 
+
+# NOTE: should maybe check `if room_environment:` here too to save it running
+#		this when it doesnt have to (or doing anything weird i didnt think of)
+#		but i think it works and i dont want to touch it 🙂
+#			- jack
 func clear_environment(body: Node3D) -> void:
 	if body.is_in_group("player"):
 		var camera: Camera3D = get_tree().current_scene.get_node("MainCamera")

--- a/Godot/main.tscn
+++ b/Godot/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=34 format=3 uid="uid://beuct1pjdlayy"]
+[gd_scene load_steps=33 format=3 uid="uid://beuct1pjdlayy"]
 
 [ext_resource type="PackedScene" uid="uid://b8kaqd0dtqsp1" path="res://Entities/player.tscn" id="2_0xm2m"]
 [ext_resource type="PackedScene" uid="uid://yory4i5rrii2" path="res://Common/Object Viewer/object_viewer.tscn" id="2_a6jrf"]


### PR DESCRIPTION
lets us set up different environment settings in each room (uses the WorldEnvironment as a fallback if we don't set one)